### PR TITLE
feat: allow initial prefix and tags on a statter

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -16,10 +16,14 @@ type registry struct {
 }
 
 func newRegistry(root *Statter, d time.Duration) *registry {
+	name, tags := mergeDescriptors("", root.cfg.separator, root.prefix, nil, root.tags)
+	k := newKey(name, tags)
+	defer putKey(k)
+
 	reg := &registry{
 		root: root,
 		statters: map[string]*Statter{
-			"": root,
+			k.SafeString(): root,
 		},
 		done: make(chan struct{}),
 	}

--- a/statter.go
+++ b/statter.go
@@ -34,6 +34,8 @@ type TimingReporter interface {
 type Tag [2]string
 
 type config struct {
+	prefix      string
+	tags        []Tag
 	separator   string
 	percSamples int
 	percentiles []float64
@@ -49,6 +51,20 @@ func defaultConfig() config {
 
 // Option represents a statter option function.
 type Option func(*config)
+
+// WithPrefix sets the initial prefix on a statter.
+func WithPrefix(prefix string) Option {
+	return func(c *config) {
+		c.prefix = prefix
+	}
+}
+
+// WithTags sets the initial tags on a statter.
+func WithTags(tags ...Tag) Option {
+	return func(c *config) {
+		c.tags = tags
+	}
+}
 
 // WithSeparator sets the key separator on a statter.
 func WithSeparator(sep string) Option {
@@ -101,9 +117,11 @@ func New(r Reporter, interval time.Duration, opts ...Option) *Statter {
 	}
 
 	s := &Statter{
-		cfg:  cfg,
-		r:    r,
-		pool: stats.NewPool(cfg.percSamples),
+		cfg:    cfg,
+		r:      r,
+		pool:   stats.NewPool(cfg.percSamples),
+		prefix: cfg.prefix,
+		tags:   cfg.tags,
 	}
 	s.reg = newRegistry(s, interval)
 

--- a/statter_internal_test.go
+++ b/statter_internal_test.go
@@ -6,6 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestWithPrefix(t *testing.T) {
+	cfg := defaultConfig()
+
+	WithPrefix("test-prefix")(&cfg)
+
+	assert.Equal(t, "test-prefix", cfg.prefix)
+}
+
+func TestWithTags(t *testing.T) {
+	cfg := defaultConfig()
+
+	WithTags([2]string{"foo", "bar"}, [2]string{"baz", "bat"})(&cfg)
+
+	assert.Equal(t, []Tag{[2]string{"foo", "bar"}, [2]string{"baz", "bat"}}, cfg.tags)
+}
+
 func TestWithSeparator(t *testing.T) {
 	cfg := defaultConfig()
 

--- a/statter_test.go
+++ b/statter_test.go
@@ -60,6 +60,18 @@ func TestStatter_With(t *testing.T) {
 	m.AssertExpectations(t)
 }
 
+func TestStatter_WithReturnsTheRootStatterWithEmpty(t *testing.T) {
+	m := &mockSimpleReporter{}
+
+	stats := statter.New(m, time.Second, statter.WithPrefix("prefix"), statter.WithTags(tags.Str("base", "val")))
+	t.Cleanup(func() { _ = stats.Close() })
+
+	got := stats.With("")
+
+	assert.Same(t, stats, got)
+	m.AssertExpectations(t)
+}
+
 func TestStatter_WithReturnsIdenticalStatter(t *testing.T) {
 	stats := statter.New(statter.DiscardReporter, time.Second)
 	t.Cleanup(func() { _ = stats.Close() })


### PR DESCRIPTION
This allows the initial prefix and tags to be set on the `statter` via optional arguments.

Previously, to set the initial prefix and tags `With` would need to be called, which creates a sub-Statter that cannot be closed. By setting the initial prefix and tags in the root `Statter`, this removes this issue.