### PR TITLE
feat: refactor codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
       excludes:
         - G103
         - G115
+        - G404
     revive:
       rules:
         - name: var-naming

--- a/context.go
+++ b/context.go
@@ -22,13 +22,7 @@ func WithContext(ctx context.Context, tags ...Tag) context.Context {
 	if existing != nil && len(existing.tags) > 0 {
 		merged = make([]Tag, len(existing.tags), len(existing.tags)+len(tags))
 		copy(merged, existing.tags)
-		for _, tag := range tags {
-			if i := tagIndex(merged, tag[0]); i >= 0 {
-				merged[i][1] = tag[1]
-			} else {
-				merged = append(merged, tag)
-			}
-		}
+		merged = mergeTags(merged, tags)
 	} else {
 		merged = make([]Tag, len(tags))
 		copy(merged, tags)

--- a/context.go
+++ b/context.go
@@ -1,0 +1,48 @@
+package statter
+
+import "context"
+
+type contextKey struct{}
+
+type ctxTags struct {
+	tags []Tag
+}
+
+// WithContext returns a new context with the given tags attached. If tags are
+// already present in ctx, the new tags are merged with them; a new tag whose
+// key already exists overrides the stored value.
+func WithContext(ctx context.Context, tags ...Tag) context.Context {
+	if len(tags) == 0 {
+		return ctx
+	}
+
+	existing, _ := ctx.Value(contextKey{}).(*ctxTags)
+
+	var merged []Tag
+	if existing != nil && len(existing.tags) > 0 {
+		merged = make([]Tag, len(existing.tags), len(existing.tags)+len(tags))
+		copy(merged, existing.tags)
+		for _, tag := range tags {
+			if i := tagIndex(merged, tag[0]); i >= 0 {
+				merged[i][1] = tag[1]
+			} else {
+				merged = append(merged, tag)
+			}
+		}
+	} else {
+		merged = make([]Tag, len(tags))
+		copy(merged, tags)
+	}
+
+	return context.WithValue(ctx, contextKey{}, &ctxTags{tags: merged})
+}
+
+// FromContext returns a sub-statter whose tags include those stored in ctx by
+// WithContext. If no tags are found in ctx, s is returned unchanged.
+func (s *Statter) FromContext(ctx context.Context) *Statter {
+	ct, _ := ctx.Value(contextKey{}).(*ctxTags)
+	if ct == nil || len(ct.tags) == 0 {
+		return s
+	}
+	return s.With("", ct.tags...)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,111 @@
+package statter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hamba/statter/v2"
+	"github.com/hamba/statter/v2/tags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithContext_ReturnsCtxUnchangedWhenNoTags(t *testing.T) {
+	ctx := context.Background()
+
+	got := statter.WithContext(ctx)
+
+	assert.Equal(t, ctx, got)
+}
+
+func TestWithContext_AttachesTagsToContext(t *testing.T) {
+	m := &mockSimpleReporter{}
+	m.On("Counter", "test", int64(1), [][2]string{{"env", "prod"}})
+
+	stats := statter.New(m, time.Second)
+
+	ctx := statter.WithContext(context.Background(), tags.Str("env", "prod"))
+
+	stats.FromContext(ctx).Counter("test").Inc(1)
+
+	err := stats.Close()
+	require.NoError(t, err)
+
+	m.AssertExpectations(t)
+}
+
+func TestWithContext_MergesWithExistingContextTags(t *testing.T) {
+	m := &mockSimpleReporter{}
+	m.On("Counter", "test", int64(1), [][2]string{{"env", "prod"}, {"region", "us-east"}})
+
+	stats := statter.New(m, time.Second)
+
+	ctx := statter.WithContext(context.Background(), tags.Str("env", "prod"))
+	ctx = statter.WithContext(ctx, tags.Str("region", "us-east"))
+
+	stats.FromContext(ctx).Counter("test").Inc(1)
+
+	err := stats.Close()
+	require.NoError(t, err)
+
+	m.AssertExpectations(t)
+}
+
+func TestWithContext_NewTagOverridesExistingTagWithSameKey(t *testing.T) {
+	m := &mockSimpleReporter{}
+	m.On("Counter", "test", int64(1), [][2]string{{"env", "staging"}})
+
+	stats := statter.New(m, time.Second)
+
+	ctx := statter.WithContext(context.Background(), tags.Str("env", "prod"))
+	ctx = statter.WithContext(ctx, tags.Str("env", "staging"))
+
+	stats.FromContext(ctx).Counter("test").Inc(1)
+
+	err := stats.Close()
+	require.NoError(t, err)
+
+	m.AssertExpectations(t)
+}
+
+func TestStatter_FromContextReturnsStatterWhenNoContextTags(t *testing.T) {
+	stats := statter.New(statter.DiscardReporter, time.Second)
+	t.Cleanup(func() { _ = stats.Close() })
+
+	got := stats.FromContext(context.Background())
+
+	assert.Same(t, stats, got)
+}
+
+func TestStatter_FromContextMergesContextTagsWithStatterBaseTags(t *testing.T) {
+	m := &mockSimpleReporter{}
+	m.On("Counter", "test", int64(1), [][2]string{{"base", "val"}, {"env", "prod"}})
+
+	stats := statter.New(m, time.Second, statter.WithTags(tags.Str("base", "val")))
+
+	ctx := statter.WithContext(context.Background(), tags.Str("env", "prod"))
+
+	stats.FromContext(ctx).Counter("test").Inc(1)
+
+	err := stats.Close()
+	require.NoError(t, err)
+
+	m.AssertExpectations(t)
+}
+
+func TestStatter_FromContextContextTagOverridesStatterBaseTag(t *testing.T) {
+	m := &mockSimpleReporter{}
+	m.On("Counter", "test", int64(1), [][2]string{{"env", "staging"}})
+
+	stats := statter.New(m, time.Second, statter.WithTags(tags.Str("env", "prod")))
+
+	ctx := statter.WithContext(context.Background(), tags.Str("env", "staging"))
+
+	stats.FromContext(ctx).Counter("test").Inc(1)
+
+	err := stats.Close()
+	require.NoError(t, err)
+
+	m.AssertExpectations(t)
+}

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,18 @@
-/*
-Package statter is a statistics collector with multiple reporters..
-*/
+// Package statter collects and reports statistics via a pluggable [Reporter].
+//
+// Stats are aggregated in memory and flushed to the reporter on a fixed
+// interval. Counters accumulate deltas between flushes; gauges hold their
+// last-set value. Histograms and timings are either delegated directly to
+// the reporter (when it implements [HistogramReporter] / [TimingReporter])
+// or aggregated locally and emitted as a set of derived gauges and a counter.
+//
+// Metrics are identified by a name and an optional set of key/value [Tag]
+// pairs. The [Statter.With] method creates a scoped sub-statter that
+// prepends a prefix and merges tags into every metric it records. Sub-statters
+// with identical resolved prefix and tags are deduplicated and share the same
+// instance.
+//
+// The [Reporter] interface is the only contract that backend adapters must
+// satisfy. Richer adapters may additionally implement [HistogramReporter],
+// [TimingReporter], and the corresponding Removable* interfaces.
 package statter

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/hamba/logger/v2 v2.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
-	github.com/valyala/fastrand v1.1.0
 )
 
 require (
@@ -24,6 +23,7 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/valyala/fastrand v1.1.0 // indirect
 	github.com/valyala/histogram v1.2.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -3,10 +3,9 @@ package stats
 
 import (
 	"math"
+	"math/rand/v2"
 	"sort"
 	"sync"
-
-	"github.com/valyala/fastrand"
 )
 
 // Pool is a pool of samples.
@@ -54,8 +53,6 @@ type Sample struct {
 
 	perc    []float64
 	scratch []float64
-
-	rng fastrand.RNG
 }
 
 // NewSample returns a sample with the given percentile
@@ -90,7 +87,7 @@ func (s *Sample) Add(v float64) {
 	l, c := len(s.perc), cap(s.perc)
 	if l < c {
 		s.perc = append(s.perc, v)
-	} else if n := int(s.rng.Uint32n(uint32(s.n))); n < l {
+	} else if n := int(rand.Uint32N(uint32(s.n))); n < l {
 		s.perc[n] = v
 	}
 }

--- a/key.go
+++ b/key.go
@@ -32,7 +32,9 @@ func newKey(name string, tags []Tag) *key {
 	}
 
 	// The tags must be sorted to create a consistent key.
-	sortTags(tags)
+	if len(tags) > 1 {
+		sortTags(tags)
+	}
 
 	for _, tag := range tags {
 		k.b = append(k.b, keySep)
@@ -64,15 +66,18 @@ func putKey(k *key) {
 }
 
 func sortTags(tags []Tag) {
-	var sorted bool
-	for !sorted {
-		sorted = true
-		lmo := len(tags) - 1
-		for i := range lmo {
-			if tags[i+1][0] < tags[i][0] {
-				tags[i+1], tags[i] = tags[i], tags[i+1]
-				sorted = false
+	n := len(tags)
+	for {
+		swapped := false
+		for i := 1; i < n; i++ {
+			if tags[i][0] < tags[i-1][0] {
+				tags[i], tags[i-1] = tags[i-1], tags[i]
+				swapped = true
 			}
 		}
+		if !swapped {
+			return
+		}
+		n-- // largest element is now at position n; no need to re-examine it
 	}
 }

--- a/key.go
+++ b/key.go
@@ -61,7 +61,7 @@ func (k *key) SafeString() string {
 	return string(k.b)
 }
 
-func putKey(k *key) {
+func (k *key) Release() {
 	keyPool.Put(k)
 }
 

--- a/key_internal_test.go
+++ b/key_internal_test.go
@@ -40,7 +40,7 @@ func TestKey(t *testing.T) {
 			t.Parallel()
 
 			k := newKey(test.keyName, test.keyTags)
-			defer putKey(k)
+			defer k.Release()
 
 			assert.Equal(t, test.want, k.String())
 		})
@@ -56,7 +56,7 @@ func BenchmarkKey(b *testing.B) {
 		for pb.Next() {
 			k := newKey("test", tags)
 
-			putKey(k)
+			k.Release()
 		}
 	})
 }

--- a/registry.go
+++ b/registry.go
@@ -52,7 +52,7 @@ func newRegistry(root *Statter, r Reporter, interval time.Duration, cfg config) 
 	// Register root statter in the deduplication cache.
 	k := newKey(root.prefix, root.tags)
 	reg.statters[k.SafeString()] = root
-	putKey(k)
+	k.Release()
 
 	reg.wg.Add(1)
 	go reg.runReportLoop(interval)
@@ -159,7 +159,7 @@ func (r *registry) SubStatter(parent *Statter, prefix string, tags []Tag) *Statt
 	}
 
 	k := newKey(name, newTags)
-	defer putKey(k)
+	defer k.Release()
 
 	r.mu.RLock()
 	if s, ok := r.statters[k.String()]; ok {
@@ -176,7 +176,6 @@ func (r *registry) SubStatter(parent *Statter, prefix string, tags []Tag) *Statt
 	}
 
 	r.mu.Lock()
-	// Re-check under write lock: another goroutine may have raced us here.
 	if existing, ok := r.statters[k.String()]; ok {
 		r.mu.Unlock()
 		return existing
@@ -212,13 +211,27 @@ func mergeDescriptors(prefix, sep, name string, baseTags, tags []Tag) (string, [
 
 	newTags := make([]Tag, len(baseTags), len(baseTags)+len(tags))
 	copy(newTags, baseTags)
-	for _, tag := range tags {
-		if i := tagIndex(newTags, tag[0]); i >= 0 {
-			newTags[i][1] = tag[1]
-			continue
-		}
-		newTags = append(newTags, tag)
-	}
+	newTags = mergeTags(newTags, tags)
 
 	return name, newTags
+}
+
+func mergeTags(out, tags []Tag) []Tag {
+	for _, tag := range tags {
+		if i := tagIndex(out, tag[0]); i >= 0 {
+			out[i][1] = tag[1]
+			continue
+		}
+		out = append(out, tag)
+	}
+	return out
+}
+
+func tagIndex[T ~[2]string](tags []T, key string) int {
+	for i, t := range tags {
+		if t[0] == key {
+			return i
+		}
+	}
+	return -1
 }

--- a/registry.go
+++ b/registry.go
@@ -12,8 +12,8 @@ import (
 
 type registry struct {
 	r    Reporter
-	hr   *value[HistogramReporter]
-	tr   *value[TimingReporter]
+	hr   HistogramReporter
+	tr   TimingReporter
 	pool *stats.Pool
 	cfg  config
 
@@ -33,8 +33,6 @@ type registry struct {
 func newRegistry(root *Statter, r Reporter, interval time.Duration, cfg config) *registry {
 	reg := &registry{
 		r:        r,
-		hr:       &value[HistogramReporter]{},
-		tr:       &value[TimingReporter]{},
 		pool:     stats.NewPool(cfg.percSamples),
 		cfg:      cfg,
 		root:     root,
@@ -43,10 +41,10 @@ func newRegistry(root *Statter, r Reporter, interval time.Duration, cfg config) 
 	}
 
 	if hr, ok := r.(HistogramReporter); ok {
-		reg.hr.Store(hr)
+		reg.hr = hr
 	}
 	if tr, ok := r.(TimingReporter); ok {
-		reg.tr.Store(tr)
+		reg.tr = tr
 	}
 
 	// Register root statter in the deduplication cache.
@@ -92,7 +90,7 @@ func (r *registry) report() {
 		return true
 	})
 
-	if r.hr.Load() == nil {
+	if r.hr == nil {
 		r.histograms.Range(func(_ string, h *Histogram) bool {
 			histo := h.value()
 			defer r.pool.Put(histo)
@@ -101,7 +99,7 @@ func (r *registry) report() {
 		})
 	}
 
-	if r.tr.Load() == nil {
+	if r.tr == nil {
 		r.timings.Range(func(_ string, t *Timing) bool {
 			timing := t.value()
 			defer r.pool.Put(timing)

--- a/registry.go
+++ b/registry.go
@@ -22,7 +22,7 @@ type registry struct {
 	histograms hashtriemap.HashTrieMap[string, *Histogram]
 	timings    hashtriemap.HashTrieMap[string, *Timing]
 
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	root     *Statter
 	statters map[string]*Statter
 
@@ -161,19 +161,28 @@ func (r *registry) SubStatter(parent *Statter, prefix string, tags []Tag) *Statt
 	k := newKey(name, newTags)
 	defer putKey(k)
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
+	r.mu.RLock()
 	if s, ok := r.statters[k.String()]; ok {
+		r.mu.RUnlock()
 		return s
 	}
+	r.mu.RUnlock()
 
+	// Slow path: first time we have seen this sub-statter.
 	s := &Statter{
 		reg:    r,
 		prefix: name,
 		tags:   newTags,
 	}
+
+	r.mu.Lock()
+	// Re-check under write lock: another goroutine may have raced us here.
+	if existing, ok := r.statters[k.String()]; ok {
+		r.mu.Unlock()
+		return existing
+	}
 	r.statters[k.SafeString()] = s
+	r.mu.Unlock()
 
 	return s
 }

--- a/registry.go
+++ b/registry.go
@@ -2,11 +2,26 @@ package statter
 
 import (
 	"errors"
+	"strconv"
 	"sync"
 	"time"
+
+	"github.com/go4org/hashtriemap"
+	"github.com/hamba/statter/v2/internal/stats"
 )
 
 type registry struct {
+	r    Reporter
+	hr   *value[HistogramReporter]
+	tr   *value[TimingReporter]
+	pool *stats.Pool
+	cfg  config
+
+	counters   hashtriemap.HashTrieMap[string, *Counter]
+	gauges     hashtriemap.HashTrieMap[string, *Gauge]
+	histograms hashtriemap.HashTrieMap[string, *Histogram]
+	timings    hashtriemap.HashTrieMap[string, *Timing]
+
 	mu       sync.Mutex
 	root     *Statter
 	statters map[string]*Statter
@@ -15,21 +30,32 @@ type registry struct {
 	wg   sync.WaitGroup
 }
 
-func newRegistry(root *Statter, d time.Duration) *registry {
-	name, tags := mergeDescriptors("", root.cfg.separator, root.prefix, nil, root.tags)
-	k := newKey(name, tags)
-	defer putKey(k)
-
+func newRegistry(root *Statter, r Reporter, interval time.Duration, cfg config) *registry {
 	reg := &registry{
-		root: root,
-		statters: map[string]*Statter{
-			k.SafeString(): root,
-		},
-		done: make(chan struct{}),
+		r:        r,
+		hr:       &value[HistogramReporter]{},
+		tr:       &value[TimingReporter]{},
+		pool:     stats.NewPool(cfg.percSamples),
+		cfg:      cfg,
+		root:     root,
+		statters: map[string]*Statter{},
+		done:     make(chan struct{}),
 	}
 
+	if hr, ok := r.(HistogramReporter); ok {
+		reg.hr.Store(hr)
+	}
+	if tr, ok := r.(TimingReporter); ok {
+		reg.tr.Store(tr)
+	}
+
+	// Register root statter in the deduplication cache.
+	k := newKey(root.prefix, root.tags)
+	reg.statters[k.SafeString()] = root
+	putKey(k)
+
 	reg.wg.Add(1)
-	go reg.runReportLoop(d)
+	go reg.runReportLoop(interval)
 
 	return reg
 }
@@ -52,23 +78,87 @@ func (r *registry) runReportLoop(d time.Duration) {
 }
 
 func (r *registry) report() {
-	r.mu.Lock()
-	snapshot := make([]*Statter, 0, len(r.statters))
-	for _, s := range r.statters {
-		snapshot = append(snapshot, s)
-	}
-	r.mu.Unlock()
+	r.counters.Range(func(_ string, c *Counter) bool {
+		val := c.value()
+		if val == 0 {
+			return true
+		}
+		r.r.Counter(c.name, val, c.tags)
+		return true
+	})
 
-	for _, s := range snapshot {
-		s.report()
+	r.gauges.Range(func(_ string, g *Gauge) bool {
+		r.r.Gauge(g.name, g.value(), g.tags)
+		return true
+	})
+
+	if r.hr.Load() == nil {
+		r.histograms.Range(func(_ string, h *Histogram) bool {
+			histo := h.value()
+			defer r.pool.Put(histo)
+			r.reportSample(h.name, "", h.tags, histo)
+			return true
+		})
 	}
+
+	if r.tr.Load() == nil {
+		r.timings.Range(func(_ string, t *Timing) bool {
+			timing := t.value()
+			defer r.pool.Put(timing)
+			r.reportSample(t.name, "_ms", t.tags, timing)
+			return true
+		})
+	}
+}
+
+func (r *registry) reportSample(name, suffix string, tags [][2]string, sample *stats.Sample) {
+	if sample.Count() == 0 {
+		return
+	}
+
+	prefix := name + "_"
+	r.r.Counter(prefix+"count", sample.Count(), tags)
+	r.r.Gauge(prefix+"sum"+suffix, sample.Sum(), tags)
+	r.r.Gauge(prefix+"mean"+suffix, sample.Mean(), tags)
+	r.r.Gauge(prefix+"stddev"+suffix, sample.StdDev(), tags)
+	r.r.Gauge(prefix+"min"+suffix, sample.Min(), tags)
+	r.r.Gauge(prefix+"max"+suffix, sample.Max(), tags)
+	ps := r.cfg.percentiles
+	vs := sample.Percentiles(ps)
+	for i := range vs {
+		n := prefix + strconv.FormatFloat(ps[i], 'g', -1, 64) + "p" + suffix
+		r.r.Gauge(n, vs[i], tags)
+	}
+}
+
+func (r *registry) sampleKeys(name, suffix string) []string {
+	prefix := name + "_"
+	keys := make([]string, 0, 6+len(r.cfg.percentiles))
+	keys = append(keys, prefix+"count")
+	keys = append(keys, prefix+"sum"+suffix)
+	keys = append(keys, prefix+"mean"+suffix)
+	keys = append(keys, prefix+"stddev"+suffix)
+	keys = append(keys, prefix+"min"+suffix)
+	keys = append(keys, prefix+"max"+suffix)
+
+	for _, p := range r.cfg.percentiles {
+		keys = append(keys, prefix+strconv.FormatFloat(p, 'g', -1, 64)+"p"+suffix)
+	}
+
+	return keys
 }
 
 // SubStatter returns a unique sub statter.
 func (r *registry) SubStatter(parent *Statter, prefix string, tags []Tag) *Statter {
-	name, tags := mergeDescriptors(parent.prefix, parent.cfg.separator, prefix, parent.tags, tags)
+	name, newTags := mergeDescriptors(parent.prefix, r.cfg.separator, prefix, parent.tags, tags)
 
-	k := newKey(name, tags)
+	// Sort merged tags to maintain the sorted-base-tags invariant so that
+	// the mergeDescriptors fast paths in metric accessors are safe.
+	if len(newTags) > 1 {
+		sortTags(newTags)
+	}
+
+	k := newKey(name, newTags)
 	defer putKey(k)
 
 	r.mu.Lock()
@@ -79,14 +169,9 @@ func (r *registry) SubStatter(parent *Statter, prefix string, tags []Tag) *Statt
 	}
 
 	s := &Statter{
-		cfg:    parent.cfg,
 		reg:    r,
-		r:      parent.r,
-		hr:     parent.hr,
-		tr:     parent.tr,
-		pool:   parent.pool,
 		prefix: name,
-		tags:   tags,
+		tags:   newTags,
 	}
 	r.statters[k.SafeString()] = s
 

--- a/reporter/l2met/l2met.go
+++ b/reporter/l2met/l2met.go
@@ -1,4 +1,4 @@
-// Package l2met implements an l2met stats client.
+// Package l2met implements a l2met stats client.
 package l2met
 
 import (

--- a/reporter/prometheus/prometheus.go
+++ b/reporter/prometheus/prometheus.go
@@ -1,4 +1,4 @@
-// Package prometheus implements an prometheus stats client.
+// Package prometheus implements a prometheus stats client.
 package prometheus
 
 import (
@@ -13,10 +13,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// Option represents statsd option function.
+// Option represents a prometheus option function.
 type Option func(p *Prometheus)
 
-// WithBuckets sets the buckets to used with histograms.
+// WithBuckets sets the buckets to use with histograms.
 func WithBuckets(buckets []float64) Option {
 	return func(p *Prometheus) {
 		p.defBuckets = buckets
@@ -57,7 +57,7 @@ func New(namespace string, opts ...Option) *Prometheus {
 	return p
 }
 
-// Handler gets the prometheus HTTP handler.
+// Handler returns the prometheus HTTP handler for scraping metrics.
 func (p *Prometheus) Handler() http.Handler {
 	return promhttp.HandlerFor(p.reg, promhttp.HandlerOpts{})
 }

--- a/reporter/statsd/statsd.go
+++ b/reporter/statsd/statsd.go
@@ -1,4 +1,4 @@
-// Package statsd implements an statsd client.
+// Package statsd implements a statsd client.
 package statsd
 
 import (
@@ -21,7 +21,7 @@ func defaultConfig() config {
 	}
 }
 
-// Option represents statsd option function.
+// Option represents a statsd option function.
 type Option func(*config)
 
 // WithFlushInterval sets the maximum flushInterval for packet sending.
@@ -32,8 +32,8 @@ func WithFlushInterval(interval time.Duration) Option {
 	}
 }
 
-// WithFlushBytes sets the maximum udp packet size that will be sent.
-// Defaults to 1432 flushBytes.
+// WithFlushBytes sets the maximum UDP packet size in bytes that will be sent.
+// Defaults to 1432 bytes.
 func WithFlushBytes(bytes int) Option {
 	return func(c *config) {
 		c.flushBytes = bytes

--- a/reporter/victoriametrics/victoria_metrics.go
+++ b/reporter/victoriametrics/victoria_metrics.go
@@ -1,4 +1,4 @@
-// Package victoriametrics implements an victoria metrics stats reporter.
+// Package victoriametrics implements a VictoriaMetrics stats reporter.
 package victoriametrics
 
 import (
@@ -35,7 +35,7 @@ func New() *VictoriaMetrics {
 	}
 }
 
-// Handler gets the victoria metrics HTTP handler.
+// Handler returns the VictoriaMetrics HTTP handler for scraping metrics in Prometheus format.
 func (m *VictoriaMetrics) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		m.set.WritePrometheus(w)

--- a/statter.go
+++ b/statter.go
@@ -111,7 +111,9 @@ type Statter struct {
 	tags   []Tag
 }
 
-// New returns a statter.
+// New returns a Statter that aggregates stats and flushes them to r on every
+// interval tick. Options may be used to set an initial prefix, tags, key
+// separator, and percentile configuration.
 func New(r Reporter, interval time.Duration, opts ...Option) *Statter {
 	cfg := defaultConfig()
 
@@ -134,14 +136,23 @@ func New(r Reporter, interval time.Duration, opts ...Option) *Statter {
 	return s
 }
 
-// With returns a statter with the given prefix and tags.
+// With returns a sub-statter whose metrics are prefixed with prefix and carry
+// the additional tags. The prefix is joined to the parent prefix with the
+// configured separator. Tags are merged with the parent tags; a call-site tag
+// whose key already exists in the parent overrides the parent value.
+//
+// Sub-statters with the same resolved prefix and tags are deduplicated: the
+// same instance is returned for repeated calls with identical arguments.
 func (s *Statter) With(prefix string, tags ...Tag) *Statter {
 	return s.reg.SubStatter(s, prefix, tags)
 }
 
-// Reporter returns the stats reporter.
+// Reporter returns the underlying stats reporter.
 //
-// The reporter should not be used directly.
+// The reporter is exposed for advanced use cases such as pre-registering
+// metrics with helpers like RegisterCounter, RegisterGauge, and
+// RegisterHistogram. Observing or mutating stats through the reporter
+// directly bypasses aggregation and should otherwise be avoided.
 func (s *Statter) Reporter() Reporter {
 	return s.reg.r
 }
@@ -165,7 +176,9 @@ func (s *Statter) HasCounter(name string, tags ...Tag) bool {
 	return ok
 }
 
-// Counter returns a counter for the given name and tags.
+// Counter returns a counter for the given name and tags. The counter is
+// created on the first call and the same instance is returned for subsequent
+// calls with identical name and tags.
 func (s *Statter) Counter(name string, tags ...Tag) *Counter {
 	n, t := s.mergeDescriptors(name, tags)
 	k := newKey(n, t)
@@ -198,7 +211,9 @@ func (s *Statter) HasGauge(name string, tags ...Tag) bool {
 	return ok
 }
 
-// Gauge returns a gauge for the given name and tags.
+// Gauge returns a gauge for the given name and tags. The gauge is created on
+// the first call and the same instance is returned for subsequent calls with
+// identical name and tags.
 func (s *Statter) Gauge(name string, tags ...Tag) *Gauge {
 	n, t := s.mergeDescriptors(name, tags)
 	k := newKey(n, t)
@@ -231,7 +246,14 @@ func (s *Statter) HasHistogram(name string, tags ...Tag) bool {
 	return ok
 }
 
-// Histogram returns a histogram for the given name and tags.
+// Histogram returns a histogram for the given name and tags. The histogram is
+// created on the first call and the same instance is returned for subsequent
+// calls with identical name and tags.
+//
+// When the reporter implements [HistogramReporter], observations are delegated
+// to it directly. Otherwise observations are aggregated locally and reported
+// each interval as a set of gauges (_sum, _mean, _stddev, _min, _max, and
+// each configured percentile) plus a _count counter.
 func (s *Statter) Histogram(name string, tags ...Tag) *Histogram {
 	n, t := s.mergeDescriptors(name, tags)
 	k := newKey(n, t)
@@ -261,7 +283,15 @@ func (s *Statter) HasTiming(name string, tags ...Tag) bool {
 	return ok
 }
 
-// Timing returns a timing for the given name and tags.
+// Timing returns a timing for the given name and tags. The timing is created
+// on the first call and the same instance is returned for subsequent calls
+// with identical name and tags.
+//
+// When the reporter implements [TimingReporter], observations are delegated
+// to it directly. Otherwise observations are aggregated locally in
+// milliseconds and reported each interval as a set of gauges
+// (_sum_ms, _mean_ms, _stddev_ms, _min_ms, _max_ms, and each configured
+// percentile) plus a _count counter.
 func (s *Statter) Timing(name string, tags ...Tag) *Timing {
 	n, tags := s.mergeDescriptors(name, tags)
 	k := newKey(n, tags)
@@ -326,7 +356,9 @@ func tagIndex[T ~[2]string](tags []T, key string) int {
 	return -1
 }
 
-// Close closes the statter and reporter.
+// Close stops the reporting loop, flushes any pending stats to the reporter,
+// and closes the reporter if it implements [io.Closer]. Close must be called
+// on the root statter; calling it on a sub-statter returns an error.
 func (s *Statter) Close() error {
 	if err := s.reg.Close(s); err != nil {
 		return err
@@ -341,7 +373,8 @@ func (s *Statter) Close() error {
 	return nil
 }
 
-// Counter implements a counter.
+// Counter implements a counter that monotonically accumulates a value between
+// flushes. The accumulated delta is reported and reset to zero on each flush.
 type Counter struct {
 	name string
 	tags [][2]string
@@ -351,7 +384,7 @@ type Counter struct {
 	val atomic.Int64
 }
 
-// Inc increments the counter.
+// Inc increments the counter by v.
 func (c *Counter) Inc(v int64) {
 	c.val.Add(v)
 }
@@ -368,7 +401,8 @@ func (c *Counter) value() int64 {
 	return c.val.Swap(0)
 }
 
-// Gauge implements a gauge.
+// Gauge implements a gauge that holds its last-set value and reports it on
+// each flush.
 type Gauge struct {
 	name string
 	tags [][2]string
@@ -393,8 +427,7 @@ func (g *Gauge) Dec() {
 	g.Add(-1)
 }
 
-// Add increases the gauge's value by the argument.
-// The operation is thread-safe.
+// Add increases the gauge's value by v.
 func (g *Gauge) Add(v float64) {
 	for {
 		oldBits := g.val.Load()
@@ -410,7 +443,7 @@ func (g *Gauge) Sub(v float64) {
 	g.Add(v * -1)
 }
 
-// Delete remove the gauge.
+// Delete removes the gauge.
 func (g *Gauge) Delete() {
 	if rr, ok := g.reg.r.(RemovableReporter); ok {
 		rr.RemoveGauge(g.name, g.tags)
@@ -424,6 +457,11 @@ func (g *Gauge) value() float64 {
 }
 
 // Histogram implements a histogram.
+//
+// When the reporter implements [HistogramReporter], observations are delegated
+// to it directly. Otherwise observations are aggregated locally and reported
+// each interval as a set of gauges (_sum, _mean, _stddev, _min, _max, and
+// each configured percentile) plus a _count counter.
 type Histogram struct {
 	hrFn func(v float64)
 	name string
@@ -490,6 +528,12 @@ func (h *Histogram) value() *stats.Sample {
 }
 
 // Timing implements a timing.
+//
+// When the reporter implements [TimingReporter], observations are delegated to
+// it directly. Otherwise observations are aggregated locally in milliseconds
+// and reported each interval as a set of gauges (_sum_ms, _mean_ms,
+// _stddev_ms, _min_ms, _max_ms, and each configured percentile) plus a
+// _count counter.
 type Timing struct {
 	trFn func(v time.Duration)
 	name string

--- a/statter.go
+++ b/statter.go
@@ -3,12 +3,10 @@ package statter
 import (
 	"io"
 	"math"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/go4org/hashtriemap"
 	"github.com/hamba/statter/v2/internal/stats"
 )
 
@@ -108,21 +106,9 @@ func WithPercentiles(p []float64) Option {
 
 // Statter collects and reports stats.
 type Statter struct {
-	cfg config
-	reg *registry
-
-	r    Reporter
-	hr   *value[HistogramReporter]
-	tr   *value[TimingReporter]
-	pool *stats.Pool
-
+	reg    *registry
 	prefix string
 	tags   []Tag
-
-	counters   hashtriemap.HashTrieMap[string, *Counter]
-	gauges     hashtriemap.HashTrieMap[string, *Gauge]
-	histograms hashtriemap.HashTrieMap[string, *Histogram]
-	timings    hashtriemap.HashTrieMap[string, *Timing]
 }
 
 // New returns a statter.
@@ -133,23 +119,17 @@ func New(r Reporter, interval time.Duration, opts ...Option) *Statter {
 		opt(&cfg)
 	}
 
+	// Sort initial tags once to maintain the sorted-base-tags invariant,
+	// enabling zero-alloc fast paths in mergeDescriptors.
+	if len(cfg.tags) > 1 {
+		sortTags(cfg.tags)
+	}
+
 	s := &Statter{
-		cfg:    cfg,
-		r:      r,
-		hr:     &value[HistogramReporter]{},
-		tr:     &value[TimingReporter]{},
-		pool:   stats.NewPool(cfg.percSamples),
 		prefix: cfg.prefix,
 		tags:   cfg.tags,
 	}
-	s.reg = newRegistry(s, interval)
-
-	if hr, ok := r.(HistogramReporter); ok {
-		s.hr.Store(hr)
-	}
-	if tr, ok := r.(TimingReporter); ok {
-		s.tr.Store(tr)
-	}
+	s.reg = newRegistry(s, r, interval, cfg)
 
 	return s
 }
@@ -163,42 +143,42 @@ func (s *Statter) With(prefix string, tags ...Tag) *Statter {
 //
 // The reporter should not be used directly.
 func (s *Statter) Reporter() Reporter {
-	return s.r
+	return s.reg.r
 }
 
 // FullName returns the full name with prefix for the given name.
 func (s *Statter) FullName(name string) string {
 	if s.prefix != "" {
-		return s.prefix + s.cfg.separator + name
+		return s.prefix + s.reg.cfg.separator + name
 	}
 	return name
 }
 
 // HasCounter determines if the counter exists.
 func (s *Statter) HasCounter(name string, tags ...Tag) bool {
-	k := newKey(name, tags)
+	n, t := s.mergeDescriptors(name, tags)
+	k := newKey(n, t)
 
-	_, ok := s.counters.Load(k.String())
+	_, ok := s.reg.counters.Load(k.String())
 
 	putKey(k)
-
 	return ok
 }
 
 // Counter returns a counter for the given name and tags.
 func (s *Statter) Counter(name string, tags ...Tag) *Counter {
-	k := newKey(name, tags)
+	n, t := s.mergeDescriptors(name, tags)
+	k := newKey(n, t)
 
-	c, ok := s.counters.Load(k.String())
+	c, ok := s.reg.counters.Load(k.String())
 	if !ok {
-		n, t := s.mergeDescriptors(name, tags)
 		counter := &Counter{
-			name:    n,
-			tags:    t,
-			key:     k.SafeString(),
-			statter: s,
+			name: n,
+			tags: t,
+			key:  k.String(),
+			reg:  s.reg,
 		}
-		c, _ = s.counters.LoadOrStore(k.String(), counter)
+		c, _ = s.reg.counters.LoadOrStore(k.String(), counter)
 	}
 
 	putKey(k)
@@ -208,9 +188,10 @@ func (s *Statter) Counter(name string, tags ...Tag) *Counter {
 
 // HasGauge determines if the gauge exists.
 func (s *Statter) HasGauge(name string, tags ...Tag) bool {
-	k := newKey(name, tags)
+	n, t := s.mergeDescriptors(name, tags)
+	k := newKey(n, t)
 
-	_, ok := s.gauges.Load(k.String())
+	_, ok := s.reg.gauges.Load(k.String())
 
 	putKey(k)
 
@@ -219,18 +200,18 @@ func (s *Statter) HasGauge(name string, tags ...Tag) bool {
 
 // Gauge returns a gauge for the given name and tags.
 func (s *Statter) Gauge(name string, tags ...Tag) *Gauge {
-	k := newKey(name, tags)
+	n, t := s.mergeDescriptors(name, tags)
+	k := newKey(n, t)
 
-	g, ok := s.gauges.Load(k.String())
+	g, ok := s.reg.gauges.Load(k.String())
 	if !ok {
-		n, t := s.mergeDescriptors(name, tags)
 		gauge := &Gauge{
-			name:    n,
-			tags:    t,
-			key:     k.SafeString(),
-			statter: s,
+			name: n,
+			tags: t,
+			key:  k.String(),
+			reg:  s.reg,
 		}
-		g, _ = s.gauges.LoadOrStore(k.String(), gauge)
+		g, _ = s.reg.gauges.LoadOrStore(k.String(), gauge)
 	}
 
 	putKey(k)
@@ -240,9 +221,10 @@ func (s *Statter) Gauge(name string, tags ...Tag) *Gauge {
 
 // HasHistogram determines if the histogram exists.
 func (s *Statter) HasHistogram(name string, tags ...Tag) bool {
-	k := newKey(name, tags)
+	n, t := s.mergeDescriptors(name, tags)
+	k := newKey(n, t)
 
-	_, ok := s.histograms.Load(k.String())
+	_, ok := s.reg.histograms.Load(k.String())
 
 	putKey(k)
 
@@ -251,15 +233,15 @@ func (s *Statter) HasHistogram(name string, tags ...Tag) bool {
 
 // Histogram returns a histogram for the given name and tags.
 func (s *Statter) Histogram(name string, tags ...Tag) *Histogram {
-	k := newKey(name, tags)
+	n, t := s.mergeDescriptors(name, tags)
+	k := newKey(n, t)
 
-	h, ok := s.histograms.Load(k.String())
+	h, ok := s.reg.histograms.Load(k.String())
 	if !ok {
-		n, t := s.mergeDescriptors(name, tags)
-		histogram := newHistogram(s.hr.Load(), n, t, s.pool)
+		histogram := newHistogram(s.reg.hr.Load(), n, t, s.reg.pool)
 		histogram.key = k.SafeString()
-		histogram.statter = s
-		h, _ = s.histograms.LoadOrStore(k.String(), histogram)
+		histogram.reg = s.reg
+		h, _ = s.reg.histograms.LoadOrStore(k.String(), histogram)
 	}
 
 	putKey(k)
@@ -269,9 +251,10 @@ func (s *Statter) Histogram(name string, tags ...Tag) *Histogram {
 
 // HasTiming determines if the timing exists.
 func (s *Statter) HasTiming(name string, tags ...Tag) bool {
-	k := newKey(name, tags)
+	n, t := s.mergeDescriptors(name, tags)
+	k := newKey(n, t)
 
-	_, ok := s.timings.Load(k.String())
+	_, ok := s.reg.timings.Load(k.String())
 
 	putKey(k)
 
@@ -280,15 +263,15 @@ func (s *Statter) HasTiming(name string, tags ...Tag) bool {
 
 // Timing returns a timing for the given name and tags.
 func (s *Statter) Timing(name string, tags ...Tag) *Timing {
-	k := newKey(name, tags)
+	n, tags := s.mergeDescriptors(name, tags)
+	k := newKey(n, tags)
 
-	t, ok := s.timings.Load(k.String())
+	t, ok := s.reg.timings.Load(k.String())
 	if !ok {
-		n, newTags := s.mergeDescriptors(name, tags)
-		timing := newTiming(s.tr.Load(), n, newTags, s.pool)
+		timing := newTiming(s.reg.tr.Load(), n, tags, s.reg.pool)
 		timing.key = k.SafeString()
-		timing.statter = s
-		t, _ = s.timings.LoadOrStore(k.String(), timing)
+		timing.reg = s.reg
+		t, _ = s.reg.timings.LoadOrStore(k.String(), timing)
 	}
 
 	putKey(k)
@@ -296,85 +279,32 @@ func (s *Statter) Timing(name string, tags ...Tag) *Timing {
 	return t
 }
 
-func (s *Statter) report() {
-	s.counters.Range(func(_ string, c *Counter) bool {
-		val := c.value()
-		if val == 0 {
-			return true
-		}
-		s.r.Counter(c.name, val, c.tags)
-		return true
-	})
-
-	s.gauges.Range(func(_ string, g *Gauge) bool {
-		s.r.Gauge(g.name, g.value(), g.tags)
-		return true
-	})
-
-	if s.hr.Load() == nil {
-		s.histograms.Range(func(_ string, h *Histogram) bool {
-			histo := h.value()
-			defer s.pool.Put(histo)
-
-			s.reportSample(h.name, "", h.tags, histo)
-			return true
-		})
-	}
-
-	if s.tr.Load() == nil {
-		s.timings.Range(func(_ string, t *Timing) bool {
-			timing := t.value()
-			defer s.pool.Put(timing)
-
-			s.reportSample(t.name, "_ms", t.tags, timing)
-			return true
-		})
-	}
-}
-
-func (s *Statter) reportSample(name, suffix string, tags [][2]string, sample *stats.Sample) {
-	if sample.Count() == 0 {
-		return
-	}
-
-	prefix := name + "_"
-	s.r.Counter(prefix+"count", sample.Count(), tags)
-	s.r.Gauge(prefix+"sum"+suffix, sample.Sum(), tags)
-	s.r.Gauge(prefix+"mean"+suffix, sample.Mean(), tags)
-	s.r.Gauge(prefix+"stddev"+suffix, sample.StdDev(), tags)
-	s.r.Gauge(prefix+"min"+suffix, sample.Min(), tags)
-	s.r.Gauge(prefix+"max"+suffix, sample.Max(), tags)
-	ps := s.cfg.percentiles
-	vs := sample.Percentiles(ps)
-	for i := range vs {
-		name := prefix + strconv.FormatFloat(ps[i], 'g', -1, 64) + "p" + suffix
-		s.r.Gauge(name, vs[i], tags)
-	}
-}
-
-func (s *Statter) sampleKeys(name, suffix string) []string {
-	prefix := name + "_"
-	keys := make([]string, 0, 6+len(s.cfg.percentiles))
-	keys = append(keys, prefix+"count")
-	keys = append(keys, prefix+"sum"+suffix)
-	keys = append(keys, prefix+"mean"+suffix)
-	keys = append(keys, prefix+"stddev"+suffix)
-	keys = append(keys, prefix+"min"+suffix)
-	keys = append(keys, prefix+"max"+suffix)
-
-	for _, p := range s.cfg.percentiles {
-		keys = append(keys, prefix+strconv.FormatFloat(p, 'g', -1, 64)+"p"+suffix)
-	}
-
-	return keys
-}
-
-func (s *Statter) mergeDescriptors(name string, tags []Tag) (string, [][2]string) {
+func (s *Statter) mergeDescriptors(name string, tags []Tag) (string, []Tag) {
 	if s.prefix != "" {
-		name = s.prefix + s.cfg.separator + name
+		name = s.prefix + s.reg.cfg.separator + name
 	}
 
-	newTags := make([][2]string, len(s.tags), len(s.tags)+len(tags))
+	// Fast path: no tags at all.
+	if len(s.tags) == 0 && len(tags) == 0 {
+		return name, nil
+	}
+
+	// Fast path: no base tags, single call-site tag — no key duplication possible.
+	// The variadic is a fresh slice per call; safe to return directly.
+	if len(s.tags) == 0 && len(tags) == 1 {
+		return name, tags
+	}
+
+	// Fast path: no call-site tags — return base tags directly.
+	// Safe because s.tags is pre-sorted (invariant) and immutable after statter
+	// creation. newKey calls sortTags which is a no-op read for sorted input.
+	if len(tags) == 0 {
+		return name, s.tags
+	}
+
+	// General path: merge base tags and call-site tags with deduplication.
+	// Also handles multiple call-site tags that may share the same key.
+	newTags := make([]Tag, len(s.tags), len(s.tags)+len(tags))
 	copy(newTags, s.tags)
 	for _, tag := range tags {
 		if i := tagIndex(newTags, tag[0]); i >= 0 {
@@ -402,7 +332,7 @@ func (s *Statter) Close() error {
 		return err
 	}
 
-	if c, ok := s.r.(io.Closer); ok {
+	if c, ok := s.reg.r.(io.Closer); ok {
 		if err := c.Close(); err != nil {
 			return err
 		}
@@ -413,10 +343,10 @@ func (s *Statter) Close() error {
 
 // Counter implements a counter.
 type Counter struct {
-	name    string
-	tags    [][2]string
-	key     string
-	statter *Statter
+	name string
+	tags [][2]string
+	key  string
+	reg  *registry
 
 	val atomic.Int64
 }
@@ -428,10 +358,10 @@ func (c *Counter) Inc(v int64) {
 
 // Delete removes the counter.
 func (c *Counter) Delete() {
-	if rr, ok := c.statter.r.(RemovableReporter); ok {
+	if rr, ok := c.reg.r.(RemovableReporter); ok {
 		rr.RemoveCounter(c.name, c.tags)
 	}
-	_, _ = c.statter.counters.LoadAndDelete(c.key)
+	_, _ = c.reg.counters.LoadAndDelete(c.key)
 }
 
 func (c *Counter) value() int64 {
@@ -440,10 +370,10 @@ func (c *Counter) value() int64 {
 
 // Gauge implements a gauge.
 type Gauge struct {
-	name    string
-	tags    [][2]string
-	key     string
-	statter *Statter
+	name string
+	tags [][2]string
+	key  string
+	reg  *registry
 
 	val atomic.Uint64
 }
@@ -482,10 +412,10 @@ func (g *Gauge) Sub(v float64) {
 
 // Delete remove the gauge.
 func (g *Gauge) Delete() {
-	if rr, ok := g.statter.r.(RemovableReporter); ok {
+	if rr, ok := g.reg.r.(RemovableReporter); ok {
 		rr.RemoveGauge(g.name, g.tags)
 	}
-	_, _ = g.statter.gauges.LoadAndDelete(g.key)
+	_, _ = g.reg.gauges.LoadAndDelete(g.key)
 }
 
 func (g *Gauge) value() float64 {
@@ -495,12 +425,12 @@ func (g *Gauge) value() float64 {
 
 // Histogram implements a histogram.
 type Histogram struct {
-	hrFn    func(v float64)
-	name    string
-	tags    [][2]string
-	key     string
-	statter *Statter
-	pool    *stats.Pool
+	hrFn func(v float64)
+	name string
+	tags [][2]string
+	key  string
+	reg  *registry
+	pool *stats.Pool
 
 	mu sync.Mutex
 	s  *stats.Sample
@@ -540,14 +470,14 @@ func (h *Histogram) Observe(v float64) {
 
 // Delete removes the histogram.
 func (h *Histogram) Delete() {
-	if rtr, ok := h.statter.r.(RemovableHistogramReporter); ok {
+	if rtr, ok := h.reg.r.(RemovableHistogramReporter); ok {
 		rtr.RemoveHistogram(h.name, h.tags)
-	} else if rr, ok := h.statter.r.(RemovableReporter); ok {
-		for _, k := range h.statter.sampleKeys(h.name, "") {
+	} else if rr, ok := h.reg.r.(RemovableReporter); ok {
+		for _, k := range h.reg.sampleKeys(h.name, "") {
 			rr.RemoveGauge(k, h.tags)
 		}
 	}
-	_, _ = h.statter.histograms.LoadAndDelete(h.key)
+	_, _ = h.reg.histograms.LoadAndDelete(h.key)
 }
 
 func (h *Histogram) value() *stats.Sample {
@@ -561,12 +491,12 @@ func (h *Histogram) value() *stats.Sample {
 
 // Timing implements a timing.
 type Timing struct {
-	trFn    func(v time.Duration)
-	name    string
-	tags    [][2]string
-	key     string
-	statter *Statter
-	pool    *stats.Pool
+	trFn func(v time.Duration)
+	name string
+	tags [][2]string
+	key  string
+	reg  *registry
+	pool *stats.Pool
 
 	mu sync.Mutex
 	s  *stats.Sample
@@ -609,14 +539,14 @@ func (t *Timing) Observe(d time.Duration) {
 
 // Delete removes the timing.
 func (t *Timing) Delete() {
-	if rtr, ok := t.statter.r.(RemovableTimingReporter); ok {
+	if rtr, ok := t.reg.r.(RemovableTimingReporter); ok {
 		rtr.RemoveTiming(t.name, t.tags)
-	} else if rr, ok := t.statter.r.(RemovableReporter); ok {
-		for _, k := range t.statter.sampleKeys(t.name, "_ms") {
+	} else if rr, ok := t.reg.r.(RemovableReporter); ok {
+		for _, k := range t.reg.sampleKeys(t.name, "_ms") {
 			rr.RemoveGauge(k, t.tags)
 		}
 	}
-	_, _ = t.statter.timings.LoadAndDelete(t.key)
+	_, _ = t.reg.timings.LoadAndDelete(t.key)
 }
 
 func (t *Timing) value() *stats.Sample {

--- a/statter.go
+++ b/statter.go
@@ -48,7 +48,7 @@ type RemovableTimingReporter interface {
 }
 
 // Tag is a stat tag.
-type Tag [2]string
+type Tag = [2]string
 
 type config struct {
 	prefix      string
@@ -417,9 +417,7 @@ func (s *Statter) mergeDescriptors(name string, tags []Tag) (string, [][2]string
 	}
 
 	newTags := make([][2]string, len(s.tags), len(s.tags)+len(tags))
-	for i, t := range s.tags {
-		newTags[i] = t
-	}
+	copy(newTags, s.tags)
 	for _, tag := range tags {
 		if i := tagIndex(newTags, tag[0]); i >= 0 {
 			newTags[i][1] = tag[1]

--- a/statter.go
+++ b/statter.go
@@ -193,11 +193,12 @@ func (s *Statter) Counter(name string, tags ...Tag) *Counter {
 	if !ok {
 		n, t := s.mergeDescriptors(name, tags)
 		counter := &Counter{
-			name:     n,
-			tags:     t,
-			deleteFn: s.deleteCounterFunc(k.SafeString(), n, t),
+			name:    n,
+			tags:    t,
+			key:     k.SafeString(),
+			statter: s,
 		}
-		c, _ = s.counters.LoadOrStore(k.SafeString(), counter)
+		c, _ = s.counters.LoadOrStore(k.String(), counter)
 	}
 
 	putKey(k)
@@ -224,11 +225,12 @@ func (s *Statter) Gauge(name string, tags ...Tag) *Gauge {
 	if !ok {
 		n, t := s.mergeDescriptors(name, tags)
 		gauge := &Gauge{
-			name:     n,
-			tags:     t,
-			deleteFn: s.deleteGaugeFunc(k.SafeString(), n, t),
+			name:    n,
+			tags:    t,
+			key:     k.SafeString(),
+			statter: s,
 		}
-		g, _ = s.gauges.LoadOrStore(k.SafeString(), gauge)
+		g, _ = s.gauges.LoadOrStore(k.String(), gauge)
 	}
 
 	putKey(k)
@@ -255,8 +257,9 @@ func (s *Statter) Histogram(name string, tags ...Tag) *Histogram {
 	if !ok {
 		n, t := s.mergeDescriptors(name, tags)
 		histogram := newHistogram(s.hr.Load(), n, t, s.pool)
-		histogram.deleteFn = s.deleteHistogramFunc(k.SafeString(), n, t)
-		h, _ = s.histograms.LoadOrStore(k.SafeString(), histogram)
+		histogram.key = k.SafeString()
+		histogram.statter = s
+		h, _ = s.histograms.LoadOrStore(k.String(), histogram)
 	}
 
 	putKey(k)
@@ -283,8 +286,9 @@ func (s *Statter) Timing(name string, tags ...Tag) *Timing {
 	if !ok {
 		n, newTags := s.mergeDescriptors(name, tags)
 		timing := newTiming(s.tr.Load(), n, newTags, s.pool)
-		timing.deleteFn = s.deleteTimingFunc(k.SafeString(), n, newTags)
-		t, _ = s.timings.LoadOrStore(k.SafeString(), timing)
+		timing.key = k.SafeString()
+		timing.statter = s
+		t, _ = s.timings.LoadOrStore(k.String(), timing)
 	}
 
 	putKey(k)
@@ -365,52 +369,6 @@ func (s *Statter) sampleKeys(name, suffix string) []string {
 	return keys
 }
 
-func (s *Statter) deleteCounterFunc(key, name string, tags [][2]string) func() {
-	return func() {
-		if rr, ok := s.r.(RemovableReporter); ok {
-			rr.RemoveCounter(name, tags)
-		}
-		_, _ = s.counters.LoadAndDelete(key)
-	}
-}
-
-func (s *Statter) deleteGaugeFunc(key, name string, tags [][2]string) func() {
-	return func() {
-		if rr, ok := s.r.(RemovableReporter); ok {
-			rr.RemoveGauge(name, tags)
-		}
-		_, _ = s.gauges.LoadAndDelete(key)
-	}
-}
-
-func (s *Statter) deleteHistogramFunc(key, name string, tags [][2]string) func() {
-	return func() {
-		if rtr, ok := s.r.(RemovableHistogramReporter); ok {
-			rtr.RemoveHistogram(name, tags)
-		} else if rr, ok := s.r.(RemovableReporter); ok {
-			keys := s.sampleKeys(name, "")
-			for _, k := range keys {
-				rr.RemoveGauge(k, tags)
-			}
-		}
-		_, _ = s.histograms.LoadAndDelete(key)
-	}
-}
-
-func (s *Statter) deleteTimingFunc(key, name string, tags [][2]string) func() {
-	return func() {
-		if rtr, ok := s.r.(RemovableTimingReporter); ok {
-			rtr.RemoveTiming(name, tags)
-		} else if rr, ok := s.r.(RemovableReporter); ok {
-			keys := s.sampleKeys(name, "_ms")
-			for _, k := range keys {
-				rr.RemoveGauge(k, tags)
-			}
-		}
-		_, _ = s.timings.LoadAndDelete(key)
-	}
-}
-
 func (s *Statter) mergeDescriptors(name string, tags []Tag) (string, [][2]string) {
 	if s.prefix != "" {
 		name = s.prefix + s.cfg.separator + name
@@ -455,9 +413,10 @@ func (s *Statter) Close() error {
 
 // Counter implements a counter.
 type Counter struct {
-	name     string
-	tags     [][2]string
-	deleteFn func()
+	name    string
+	tags    [][2]string
+	key     string
+	statter *Statter
 
 	val atomic.Int64
 }
@@ -469,7 +428,10 @@ func (c *Counter) Inc(v int64) {
 
 // Delete removes the counter.
 func (c *Counter) Delete() {
-	c.deleteFn()
+	if rr, ok := c.statter.r.(RemovableReporter); ok {
+		rr.RemoveCounter(c.name, c.tags)
+	}
+	_, _ = c.statter.counters.LoadAndDelete(c.key)
 }
 
 func (c *Counter) value() int64 {
@@ -478,9 +440,10 @@ func (c *Counter) value() int64 {
 
 // Gauge implements a gauge.
 type Gauge struct {
-	name     string
-	tags     [][2]string
-	deleteFn func()
+	name    string
+	tags    [][2]string
+	key     string
+	statter *Statter
 
 	val atomic.Uint64
 }
@@ -519,7 +482,10 @@ func (g *Gauge) Sub(v float64) {
 
 // Delete remove the gauge.
 func (g *Gauge) Delete() {
-	g.deleteFn()
+	if rr, ok := g.statter.r.(RemovableReporter); ok {
+		rr.RemoveGauge(g.name, g.tags)
+	}
+	_, _ = g.statter.gauges.LoadAndDelete(g.key)
 }
 
 func (g *Gauge) value() float64 {
@@ -529,11 +495,12 @@ func (g *Gauge) value() float64 {
 
 // Histogram implements a histogram.
 type Histogram struct {
-	hrFn     func(v float64)
-	name     string
-	tags     [][2]string
-	deleteFn func()
-	pool     *stats.Pool
+	hrFn    func(v float64)
+	name    string
+	tags    [][2]string
+	key     string
+	statter *Statter
+	pool    *stats.Pool
 
 	mu sync.Mutex
 	s  *stats.Sample
@@ -545,6 +512,8 @@ func newHistogram(hr HistogramReporter, name string, tags [][2]string, pool *sta
 		if fn != nil {
 			return &Histogram{
 				hrFn: fn,
+				name: name,
+				tags: tags,
 			}
 		}
 	}
@@ -571,7 +540,14 @@ func (h *Histogram) Observe(v float64) {
 
 // Delete removes the histogram.
 func (h *Histogram) Delete() {
-	h.deleteFn()
+	if rtr, ok := h.statter.r.(RemovableHistogramReporter); ok {
+		rtr.RemoveHistogram(h.name, h.tags)
+	} else if rr, ok := h.statter.r.(RemovableReporter); ok {
+		for _, k := range h.statter.sampleKeys(h.name, "") {
+			rr.RemoveGauge(k, h.tags)
+		}
+	}
+	_, _ = h.statter.histograms.LoadAndDelete(h.key)
 }
 
 func (h *Histogram) value() *stats.Sample {
@@ -585,11 +561,12 @@ func (h *Histogram) value() *stats.Sample {
 
 // Timing implements a timing.
 type Timing struct {
-	trFn     func(v time.Duration)
-	name     string
-	tags     [][2]string
-	deleteFn func()
-	pool     *stats.Pool
+	trFn    func(v time.Duration)
+	name    string
+	tags    [][2]string
+	key     string
+	statter *Statter
+	pool    *stats.Pool
 
 	mu sync.Mutex
 	s  *stats.Sample
@@ -601,6 +578,8 @@ func newTiming(tr TimingReporter, name string, tags [][2]string, pool *stats.Poo
 		if fn != nil {
 			return &Timing{
 				trFn: fn,
+				name: name,
+				tags: tags,
 			}
 		}
 	}
@@ -630,7 +609,14 @@ func (t *Timing) Observe(d time.Duration) {
 
 // Delete removes the timing.
 func (t *Timing) Delete() {
-	t.deleteFn()
+	if rtr, ok := t.statter.r.(RemovableTimingReporter); ok {
+		rtr.RemoveTiming(t.name, t.tags)
+	} else if rr, ok := t.statter.r.(RemovableReporter); ok {
+		for _, k := range t.statter.sampleKeys(t.name, "_ms") {
+			rr.RemoveGauge(k, t.tags)
+		}
+	}
+	_, _ = t.statter.timings.LoadAndDelete(t.key)
 }
 
 func (t *Timing) value() *stats.Sample {

--- a/statter.go
+++ b/statter.go
@@ -258,7 +258,7 @@ func (s *Statter) Histogram(name string, tags ...Tag) *Histogram {
 	h, ok := s.reg.histograms.Load(k.String())
 	if !ok {
 		n, t := s.mergeDescriptors(name, tags)
-		histogram := newHistogram(s.reg.hr.Load(), n, t, s.reg.pool)
+		histogram := newHistogram(s.reg.hr, n, t, s.reg.pool)
 		histogram.key = k.SafeString()
 		histogram.reg = s.reg
 		h, _ = s.reg.histograms.LoadOrStore(k.SafeString(), histogram)
@@ -295,7 +295,7 @@ func (s *Statter) Timing(name string, tags ...Tag) *Timing {
 	t, ok := s.reg.timings.Load(k.String())
 	if !ok {
 		n, tags := s.mergeDescriptors(name, tags)
-		timing := newTiming(s.reg.tr.Load(), n, tags, s.reg.pool)
+		timing := newTiming(s.reg.tr, n, tags, s.reg.pool)
 		timing.key = k.SafeString()
 		timing.reg = s.reg
 		t, _ = s.reg.timings.LoadOrStore(k.SafeString(), timing)
@@ -582,21 +582,4 @@ func (r discardReporter) Histogram(_ string, _ [][2]string) func(float64) {
 
 func (r discardReporter) Timing(_ string, _ [][2]string) func(time.Duration) {
 	return func(_ time.Duration) {}
-}
-
-type value[T any] struct {
-	val atomic.Value
-}
-
-func (v *value[T]) Load() T {
-	var zeroT T
-	val, ok := v.val.Load().(T)
-	if !ok {
-		return zeroT
-	}
-	return val
-}
-
-func (v *value[T]) Store(t T) {
-	v.val.Store(t)
 }

--- a/statter.go
+++ b/statter.go
@@ -167,12 +167,12 @@ func (s *Statter) FullName(name string) string {
 
 // HasCounter determines if the counter exists.
 func (s *Statter) HasCounter(name string, tags ...Tag) bool {
-	n, t := s.mergeDescriptors(name, tags)
-	k := newKey(n, t)
+	k := s.key(name, tags)
 
 	_, ok := s.reg.counters.Load(k.String())
 
-	putKey(k)
+	k.Release()
+
 	return ok
 }
 
@@ -180,33 +180,32 @@ func (s *Statter) HasCounter(name string, tags ...Tag) bool {
 // created on the first call and the same instance is returned for subsequent
 // calls with identical name and tags.
 func (s *Statter) Counter(name string, tags ...Tag) *Counter {
-	n, t := s.mergeDescriptors(name, tags)
-	k := newKey(n, t)
+	k := s.key(name, tags)
 
 	c, ok := s.reg.counters.Load(k.String())
 	if !ok {
+		n, t := s.mergeDescriptors(name, tags)
 		counter := &Counter{
 			name: n,
 			tags: t,
-			key:  k.String(),
+			key:  k.SafeString(),
 			reg:  s.reg,
 		}
-		c, _ = s.reg.counters.LoadOrStore(k.String(), counter)
+		c, _ = s.reg.counters.LoadOrStore(k.SafeString(), counter)
 	}
 
-	putKey(k)
+	k.Release()
 
 	return c
 }
 
 // HasGauge determines if the gauge exists.
 func (s *Statter) HasGauge(name string, tags ...Tag) bool {
-	n, t := s.mergeDescriptors(name, tags)
-	k := newKey(n, t)
+	k := s.key(name, tags)
 
 	_, ok := s.reg.gauges.Load(k.String())
 
-	putKey(k)
+	k.Release()
 
 	return ok
 }
@@ -215,33 +214,32 @@ func (s *Statter) HasGauge(name string, tags ...Tag) bool {
 // the first call and the same instance is returned for subsequent calls with
 // identical name and tags.
 func (s *Statter) Gauge(name string, tags ...Tag) *Gauge {
-	n, t := s.mergeDescriptors(name, tags)
-	k := newKey(n, t)
+	k := s.key(name, tags)
 
 	g, ok := s.reg.gauges.Load(k.String())
 	if !ok {
+		n, t := s.mergeDescriptors(name, tags)
 		gauge := &Gauge{
 			name: n,
 			tags: t,
-			key:  k.String(),
+			key:  k.SafeString(),
 			reg:  s.reg,
 		}
-		g, _ = s.reg.gauges.LoadOrStore(k.String(), gauge)
+		g, _ = s.reg.gauges.LoadOrStore(k.SafeString(), gauge)
 	}
 
-	putKey(k)
+	k.Release()
 
 	return g
 }
 
 // HasHistogram determines if the histogram exists.
 func (s *Statter) HasHistogram(name string, tags ...Tag) bool {
-	n, t := s.mergeDescriptors(name, tags)
-	k := newKey(n, t)
+	k := s.key(name, tags)
 
 	_, ok := s.reg.histograms.Load(k.String())
 
-	putKey(k)
+	k.Release()
 
 	return ok
 }
@@ -255,30 +253,29 @@ func (s *Statter) HasHistogram(name string, tags ...Tag) bool {
 // each interval as a set of gauges (_sum, _mean, _stddev, _min, _max, and
 // each configured percentile) plus a _count counter.
 func (s *Statter) Histogram(name string, tags ...Tag) *Histogram {
-	n, t := s.mergeDescriptors(name, tags)
-	k := newKey(n, t)
+	k := s.key(name, tags)
 
 	h, ok := s.reg.histograms.Load(k.String())
 	if !ok {
+		n, t := s.mergeDescriptors(name, tags)
 		histogram := newHistogram(s.reg.hr.Load(), n, t, s.reg.pool)
 		histogram.key = k.SafeString()
 		histogram.reg = s.reg
-		h, _ = s.reg.histograms.LoadOrStore(k.String(), histogram)
+		h, _ = s.reg.histograms.LoadOrStore(k.SafeString(), histogram)
 	}
 
-	putKey(k)
+	k.Release()
 
 	return h
 }
 
 // HasTiming determines if the timing exists.
 func (s *Statter) HasTiming(name string, tags ...Tag) bool {
-	n, t := s.mergeDescriptors(name, tags)
-	k := newKey(n, t)
+	k := s.key(name, tags)
 
 	_, ok := s.reg.timings.Load(k.String())
 
-	putKey(k)
+	k.Release()
 
 	return ok
 }
@@ -293,67 +290,39 @@ func (s *Statter) HasTiming(name string, tags ...Tag) bool {
 // (_sum_ms, _mean_ms, _stddev_ms, _min_ms, _max_ms, and each configured
 // percentile) plus a _count counter.
 func (s *Statter) Timing(name string, tags ...Tag) *Timing {
-	n, tags := s.mergeDescriptors(name, tags)
-	k := newKey(n, tags)
+	k := s.key(name, tags)
 
 	t, ok := s.reg.timings.Load(k.String())
 	if !ok {
+		n, tags := s.mergeDescriptors(name, tags)
 		timing := newTiming(s.reg.tr.Load(), n, tags, s.reg.pool)
 		timing.key = k.SafeString()
 		timing.reg = s.reg
-		t, _ = s.reg.timings.LoadOrStore(k.String(), timing)
+		t, _ = s.reg.timings.LoadOrStore(k.SafeString(), timing)
 	}
 
-	putKey(k)
+	k.Release()
 
 	return t
 }
 
-func (s *Statter) mergeDescriptors(name string, tags []Tag) (string, []Tag) {
-	if s.prefix != "" {
+func (s *Statter) key(name string, tags []Tag) *key {
+	switch {
+	case s.prefix != "" && name != "":
 		name = s.prefix + s.reg.cfg.separator + name
+	case name == "":
+		name = s.prefix
 	}
 
-	// Fast path: no tags at all.
-	if len(s.tags) == 0 && len(tags) == 0 {
-		return name, nil
-	}
+	keyTags := make([]Tag, len(s.tags), len(s.tags)+len(tags))
+	copy(keyTags, s.tags)
+	keyTags = mergeTags(keyTags, tags)
 
-	// Fast path: no base tags, single call-site tag — no key duplication possible.
-	// The variadic is a fresh slice per call; safe to return directly.
-	if len(s.tags) == 0 && len(tags) == 1 {
-		return name, tags
-	}
-
-	// Fast path: no call-site tags — return base tags directly.
-	// Safe because s.tags is pre-sorted (invariant) and immutable after statter
-	// creation. newKey calls sortTags which is a no-op read for sorted input.
-	if len(tags) == 0 {
-		return name, s.tags
-	}
-
-	// General path: merge base tags and call-site tags with deduplication.
-	// Also handles multiple call-site tags that may share the same key.
-	newTags := make([]Tag, len(s.tags), len(s.tags)+len(tags))
-	copy(newTags, s.tags)
-	for _, tag := range tags {
-		if i := tagIndex(newTags, tag[0]); i >= 0 {
-			newTags[i][1] = tag[1]
-		} else {
-			newTags = append(newTags, tag)
-		}
-	}
-
-	return name, newTags
+	return newKey(name, keyTags)
 }
 
-func tagIndex[T ~[2]string](tags []T, key string) int {
-	for i, t := range tags {
-		if t[0] == key {
-			return i
-		}
-	}
-	return -1
+func (s *Statter) mergeDescriptors(name string, tags []Tag) (string, []Tag) {
+	return mergeDescriptors(s.prefix, s.reg.cfg.separator, name, s.tags, tags)
 }
 
 // Close stops the reporting loop, flushes any pending stats to the reporter,

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -7,23 +7,23 @@ import (
 	"github.com/hamba/statter/v2"
 )
 
-// Str returns a string tag with the give key and value.
+// Str returns a string tag with the given key and value.
 func Str(k, v string) statter.Tag {
 	return [2]string{k, v}
 }
 
-// Int returns an int tag with the give key and value.
+// Int returns an int tag with the given key and value.
 func Int(k string, v int) statter.Tag {
 	return [2]string{k, strconv.Itoa(v)}
 }
 
-// Int64 returns an int64 tag with the give key and value.
+// Int64 returns an int64 tag with the given key and value.
 func Int64(k string, v int64) statter.Tag {
 	return [2]string{k, strconv.FormatInt(v, 10)}
 }
 
-// StatusCode return a tag with the given key and the status
-// code int the form '2xx'.
+// StatusCode returns a tag with the given key and the status
+// code in the form '2xx'.
 func StatusCode(k string, v int) statter.Tag {
 	code := strconv.Itoa(v)
 	return [2]string{k, string(code[0]) + "xx"}


### PR DESCRIPTION
## Goal of this PR

This refactors the codebase to tackle multiple issues, the primary being that multiple statters can produce the same metrics, separately. This includes a minor performance difference:

```
name                         old time/op    new time/op    delta
pkg:github.com/hamba/statter/v2 goos:darwin goarch:arm64
Key                            53.9ns ± 3%    52.4ns ± 2%   -2.80%  (p=0.032 n=5+5)
Statter_Counter                36.9ns ± 1%    45.2ns ± 1%  +22.43%  (p=0.008 n=5+5)
Statter_Gauge                  35.8ns ± 0%    44.8ns ± 0%  +25.35%  (p=0.008 n=5+5)
Statter_GaugeAdd               38.5ns ± 1%    45.8ns ± 1%  +18.84%  (p=0.008 n=5+5)
Statter_Histogram              47.3ns ± 0%    56.0ns ± 0%  +18.46%  (p=0.008 n=5+5)
Statter_Timing                 48.1ns ± 1%    56.3ns ± 0%  +16.98%  (p=0.008 n=5+5)
Statter_PrometheusHistogram    47.9ns ± 2%    55.6ns ± 1%  +16.08%  (p=0.008 n=5+5)
Statter_PrometheusTiming       49.9ns ± 0%    57.7ns ± 1%  +15.63%  (p=0.008 n=5+5)
pkg:github.com/hamba/statter/v2/internal/stats goos:darwin goarch:arm64
Sample                         3.96ns ± 1%    7.78ns ± 0%  +96.31%  (p=0.008 n=5+5)
Percentiles                     108ns ± 0%     108ns ± 0%   -0.53%  (p=0.016 n=5+5)
pkg:github.com/hamba/statter/v2/reporter/l2met goos:darwin goarch:arm64
L2met_Inc                      86.4ns ± 1%    84.0ns ± 0%   -2.82%  (p=0.008 n=5+5)
```

<!--
Fixes #
-->

## How did I test it?

All previous tests still pass.
